### PR TITLE
Standard form for linear problems

### DIFF
--- a/quadratic/quadratic_problem.py
+++ b/quadratic/quadratic_problem.py
@@ -18,4 +18,5 @@ class QuadraticProblem(LinearConstraintsProblem):
     bias: float = 0
     
     def __post_init__(self):
+        super(QuadraticProblem, self).__post_init__()
         self.f = lambda x: 1/2 * x @ self.G @ x + x @ self.c + self.bias

--- a/shared/minimization_problem.py
+++ b/shared/minimization_problem.py
@@ -3,7 +3,7 @@ MinimizationProblem, relevant functions and implemented methods.
 """
 
 from dataclasses import dataclass, field
-from typing import Callable, List, Sequence
+from typing import Callable, List, Sequence, Optional
 
 import numpy as np
 
@@ -27,8 +27,8 @@ class MinimizationProblem:
     f: Callable[[np.ndarray], float]
     n: int
     constraints: Sequence[Constraint]
-    x0: np.ndarray
-    solution: np.ndarray
+    x0: Optional[np.ndarray]
+    solution: Optional[np.ndarray]
 
     # --- Objective function methods ---
 

--- a/test_script.py
+++ b/test_script.py
@@ -6,8 +6,8 @@ from shared.constraints import *
 from simplex.linear_problem import *
 from quadratic.quadratic_problem import *
 
+
 def test_combined_params_linear():
-    
     A = np.array([
         [2, 3],
         [4, 5]
@@ -32,7 +32,6 @@ def test_combined_params_linear():
 
 
 def test_combined_params_quadratic():
-    
     A = np.array([
         [2, 3],
         [4, 5]
@@ -55,3 +54,29 @@ def test_combined_params_quadratic():
     assert np.all(qp.A == A)
     assert np.all(qp.b == b)
     assert qp.f(np.array([1, 1])) == 10
+
+
+def test_standard_form():
+    A = np.array([
+        [2, 3],
+        [4, 5]
+    ])
+
+    b = np.array([2, 3])
+
+    lp = LinearProblem(
+        c=np.array([2, 5]),
+        n=2,
+        constraints=[
+            LinearConstraint(c=LinearCallable(a=A[0], b=b[0]), is_equality=True),
+            LinearConstraint(c=LinearCallable(a=A[1], b=b[1]), is_equality=True),
+        ],
+        x0=None,
+        solution=None
+    )
+
+    standard_lp = lp.to_standard_form()
+
+    assert standard_lp.n == 6
+    assert standard_lp.calc_f_at(np.array((1, 2, 2, 1, 1, 2))) == 3
+    assert (standard_lp.calc_constraints_at(np.array((1, 2, 2, 1, 1, 2))) == np.array((0, 0))).all()


### PR DESCRIPTION
*added* method to convert a problem of form Ax<=b or Ax=b without positivity constraints to standard form, i.e., Ay=b, y>=0 (y>=0 is not explicitly part of the constraints)
*added* a test for standard form

also:
*fixed* setup of linear/quadratic problems
*fixed* linter errors for MinimizationProblem