### PR TITLE
Fix solve

### DIFF
--- a/shared/solve_linear_system.py
+++ b/shared/solve_linear_system.py
@@ -50,7 +50,6 @@ def LU_factorization(A: np.ndarray) -> [np.ndarray, np.ndarray, np.ndarray]:
             j = 0
             while A[i:n, i][max_idxs[j]] == 0:
                 if j == (len(max_idxs) - 1):
-                    print(A[i:n, i])
                     raise ValueError("PLU factorization isn't possible as there is a column with only 0 entries.")
                 j += 1
 

--- a/shared/solve_linear_system.py
+++ b/shared/solve_linear_system.py
@@ -64,32 +64,6 @@ def LU_factorization(A: np.ndarray) -> [np.ndarray, np.ndarray, np.ndarray]:
         L[i + 1:, i] = factor
         U[i + 1:] -= factor[:, np.newaxis] * U[i]
 
-    # old code which isn't that compact
-    """# pivot matrix
-    p = pivoting(A)
-
-    L = np.eye(A, dtype=np.float64)
-    U = np.zeros_like(A, dtype=np.float64)
-    PA = np.matmul(p, A)
-
-    for i in range(n):
-        # calculate U
-        for j in range(i,n):
-            s = 0
-            for k in range(i):
-                s += L[i, k] * U[k, j]
-            U[i, j] = PA[i, j] - s
-
-        # calculate L
-        for j in range(i, n):
-            if j == i:
-                L[i, j] = 1
-            else:
-                s = 0
-                for k in range(i):
-                    s += L[j, k] * U[k, i]
-                L[j, i] = (PA[j, i] - s) / U[i, i]"""
-
     return L, U, p
 
 

--- a/shared/solve_linear_system.py
+++ b/shared/solve_linear_system.py
@@ -24,25 +24,51 @@ def cholesky_factorization(A):
     return L
 
 
-def LU_factorization(A: np.ndarray):
+def LU_factorization(A: np.ndarray) -> [np.ndarray, np.ndarray, np.ndarray]:
     """
     factorizes a square matrix, matrix does not have to be symmetric or positive definite
-    use as A = LU
+    use as A = p @ L @ U
     :param A: matrix to decompose
-    :return: lower matrix L and upper matrix U
+    :return: lower matrix L, upper matrix U, permutation matrix p
     """
     assert A.shape[0] == A.shape[1]  # requires square matrix
 
     n = A.shape[0]
 
-    # pivot matrix
-    p = np.eye(n)
-    for j in range(n):
-        max_row = j + np.argmax(np.abs(A[j:n, j]))
-        if j != max_row:  # swap rows if off-diagonal element is bigger in j-th column
-            p[[max_row, j]] = p[[j, max_row]]
+    U = A.copy()
+    L = np.eye(n, dtype=np.double)
+    p = np.eye(n, dtype=np.double)
 
-    L = np.zeros_like(A, dtype=np.float64)
+    # Loop over rows
+    for i in range(n):
+
+        # adjust permutation matrix
+        if np.isclose(U[i, i], 0.0):
+            max_idxs = A[i:n, i].argsort()[::-1]
+
+            # loop through indices sorted according to descending values, take first index that is non-zero
+            j = 0
+            while A[i:n, i][max_idxs[j]] == 0:
+                if j == (len(max_idxs) - 1):
+                    print(A[i:n, i])
+                    raise ValueError("PLU factorization isn't possible as there is a column with only 0 entries.")
+                j += 1
+
+            max_row = i + max_idxs[j]
+            if i != max_row:  # swap rows if off-diagonal element is bigger in j-th column
+                p[[max_row, i]] = p[[i, max_row]]
+                U[[max_row, i]] = U[[i, max_row]]
+
+        # perform operations
+        factor = U[i + 1:, i] / U[i, i]
+        L[i + 1:, i] = factor
+        U[i + 1:] -= factor[:, np.newaxis] * U[i]
+
+    # old code which isn't that compact
+    """# pivot matrix
+    p = pivoting(A)
+
+    L = np.eye(A, dtype=np.float64)
     U = np.zeros_like(A, dtype=np.float64)
     PA = np.matmul(p, A)
 
@@ -62,12 +88,12 @@ def LU_factorization(A: np.ndarray):
                 s = 0
                 for k in range(i):
                     s += L[j, k] * U[k, i]
-                L[j, i] = (PA[j, i] - s) / U[i, i]
+                L[j, i] = (PA[j, i] - s) / U[i, i]"""
 
     return L, U, p
 
 
-def forward(L, b):
+def _forward_(L, b):
     y = []
     for i in range(len(b)):
         y.append(b[i])
@@ -78,7 +104,7 @@ def forward(L, b):
     return y
 
 
-def backward(Lt, y):
+def _backward_(Lt, y):
     x = np.zeros_like(y)
     for i in range(x.shape[0] , 0, -1):
         x[i - 1] = (y[i -1] - np.dot(Lt[i-1, i:],x[i:]))/Lt[i-1, i-1]
@@ -86,11 +112,11 @@ def backward(Lt, y):
     return x
 
 
-def solve(A, b, cholesky = False):
+def solve(A, b, cholesky = False) -> np.ndarray:
     """
     solves Ax = b without computing the inverse of A but uses forward/backward substitution and the specified substitution
     by default uses PLU factorization and hence can be used for arbitrary square matrices
-    (! attention: might fail if a column has only negative and 0 entries !, if needed @Franzi modifies it)
+    (! attention: tell @Franzi if it fails, she modifies it)
     :param A: square matrix
     :param b: solution to linear system
     :param cholesky: if set to false, PLU factorization is used. use cholesky only for positive definite matrices, else LU
@@ -98,12 +124,12 @@ def solve(A, b, cholesky = False):
     """
     if cholesky:
         L = cholesky_factorization(A)
-        y = forward(L, b)
-        solution = backward(L.T, y)
+        y = _forward_(L, b)
+        solution = _backward_(L.T, y)
 
     else:
         L, U, P = LU_factorization(A)
-        y = forward(L, P @ b)
-        solution = backward(U, y)
+        y = _forward_(L, P @ b)
+        solution = _backward_(U, y)
 
     return solution

--- a/simplex.ipynb
+++ b/simplex.ipynb
@@ -11,7 +11,8 @@
     "- Automatic standard form conversion\n",
     "    - Missing positivity constraints on x are added by splitting into $x^+$ and $x^-$\n",
     "    - Slack variables are added to replace inequality constraints with equality constraints\n",
-    "- Starting the simplex method"
+    "- Starting the simplex method\n",
+    "- PLU-factorization for solving linear systems"
    ]
   },
   {

--- a/simplex/base.py
+++ b/simplex/base.py
@@ -42,15 +42,8 @@ def minimize_linear_problem(original_problem: LinearProblem, standardized=False)
         c_n = problem.c[non_basis]
 
         if i == 0: # only necessary for initial run
-            # buggy atm
-            #x_b_true = np.linalg.solve(B, problem.b)
             x_b = solve(B, problem.b)
-            #print(f"x_b: {x_b}, x_b_true: {x_b_true}")
-        #print("B.T", B.T, "c_b:", c_b)
-        #lambda_true = np.linalg.solve(B.T, c_b)
-        # buggy atm
         lambda_ = solve(B.T, c_b)
-        #print(f"lambda: {lambda_}, lambda_true: {lambda_true}")
 
         s_n = c_n - N.T @ lambda_
 
@@ -63,11 +56,7 @@ def minimize_linear_problem(original_problem: LinearProblem, standardized=False)
 
         q = non_basis[np.argmin(s_n)]
         A_q = problem.A[:, q].flatten()
-        #print(f"B: {B}, A_q: {A_q}")
-        #d_true = np.linalg.solve(B, A_q)
-        # buggy atm
         d = solve(B, A_q)
-        #print(f"d: {d}, d_true: {d_true}")
 
         if np.all(d <= 0):
             raise ValueError("Problem is unbounded")

--- a/simplex/base.py
+++ b/simplex/base.py
@@ -43,12 +43,14 @@ def minimize_linear_problem(original_problem: LinearProblem, standardized=False)
 
         if i == 0: # only necessary for initial run
             # buggy atm
-            x_b = np.linalg.solve(B, problem.b)
-            #x_b = solve(B, problem.b)
-
-        lambda_ = np.linalg.solve(B.T, c_b)
+            #x_b_true = np.linalg.solve(B, problem.b)
+            x_b = solve(B, problem.b)
+            #print(f"x_b: {x_b}, x_b_true: {x_b_true}")
+        #print("B.T", B.T, "c_b:", c_b)
+        #lambda_true = np.linalg.solve(B.T, c_b)
         # buggy atm
-        #lambda_ = solve(B.T, c_b)
+        lambda_ = solve(B.T, c_b)
+        #print(f"lambda: {lambda_}, lambda_true: {lambda_true}")
 
         s_n = c_n - N.T @ lambda_
 
@@ -61,9 +63,11 @@ def minimize_linear_problem(original_problem: LinearProblem, standardized=False)
 
         q = non_basis[np.argmin(s_n)]
         A_q = problem.A[:, q].flatten()
-        d = np.linalg.solve(B, A_q)
+        #print(f"B: {B}, A_q: {A_q}")
+        #d_true = np.linalg.solve(B, A_q)
         # buggy atm
-        #d = solve(B, A_q)
+        d = solve(B, A_q)
+        #print(f"d: {d}, d_true: {d_true}")
 
         if np.all(d <= 0):
             raise ValueError("Problem is unbounded")


### PR DESCRIPTION
I modified PLU factorization such that it works on sparse matrices and also with only 0 and negative entries. Didn't encounter a case unit now where it doesn't work (expect when a column has only 0 entries but then PLU-factorization in generel isn't possible and a ValueError is raised). Solve should now work again in the base.py file of the simplex method. The quadratic tests also did work when I tried them.
The PLU factorization also got a little bit more compact and needs less loops and operations to find the (hopefully) correct solution.